### PR TITLE
Break retain cycle caused by BPAboutViewController in BPDoubleAboutRow

### DIFF
--- a/BuyPolish/Pola/UI/ProductSearch/About/model/BPDoubleAboutRow.h
+++ b/BuyPolish/Pola/UI/ProductSearch/About/model/BPDoubleAboutRow.h
@@ -4,7 +4,7 @@
 
 @property (copy, nonatomic) NSString *secondTitle;
 @property (nonatomic) SEL secondAction;
-@property (nonatomic) id target;
+@property (weak, nonatomic) id target;
 
 + (instancetype)rowWithTitle:(NSString *)title action:(SEL)action secondTitle:(NSString *)secondTitle secondAction:(SEL)secondAction target:(id)target;
 


### PR DESCRIPTION
DBDoubleAboutRow is created by BPAboutViewController with reference to self
(target) and one of its selectors. DBDoubleAboutRow is stored in array that
the controller has strong reference to, and the row item has strong reference
to target (view controller).

Thus, BPAboutViewController and all its children was never released because of
the retain cycle which could cause big memory footprint (3x bigger after serveral
enters into menu view).


Also some screenshots from testing.

Before fix:
![before-fix](https://cloud.githubusercontent.com/assets/2303177/13631868/2bdec6e8-e5e7-11e5-9a8e-78db9d7dd12b.png)

After fix:
![after-fix](https://cloud.githubusercontent.com/assets/2303177/13631890/450c5e32-e5e7-11e5-873e-c8cddd0f4086.png)
