### PR TITLE
Triggeruj Github Action tylko raz na PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
 
 jobs:
   build:


### PR DESCRIPTION
Hello,

Nasz CI uruchamia się 2 razy dla każdego PR. Teraz go skonfigurowałem, aby uruchamiał się tylko raz.(`pull_request`), a potem uruchamia drugi raz, gdy zmiana jest już scalona (`push`). Dodatkowym plusem takiego rozdziellenia jest to, że możemy w oparciu o typ zdarzenia budować CD.

Tutaj przykład, który wdraża środowisko, gdy zostaje scalone do gałęzi głównej.
```yaml
      - name: Terraform Apply
        if: github.event_name == 'push'
        run: terraform apply
```
Z wyrazami szacunku