### PR TITLE
Włączenie edycji (przycinania) zdjęcia po wybraniu z galerii.

### DIFF
--- a/BuyPolish/Pola/UI/ProductSearch/ScanCode/ScanCodeViewController.swift
+++ b/BuyPolish/Pola/UI/ProductSearch/ScanCode/ScanCodeViewController.swift
@@ -15,7 +15,7 @@ final class ScanCodeViewController: UIViewController {
     private lazy var imagePicker: UIImagePickerController = {
         let picker = UIImagePickerController()
         picker.delegate = self
-        picker.allowsEditing = false
+        picker.allowsEditing = true
         picker.mediaTypes = [String(kUTTypeImage)]
         picker.sourceType = .photoLibrary
         return picker
@@ -227,14 +227,14 @@ extension ScanCodeViewController: UIImagePickerControllerDelegate {
 
         KVNProgress.show(withStatus: R.string.localizable.searchingForBarcode())
 
-        guard let originalImage = info[.originalImage] as? UIImage else {
+        guard let editedImage = info[.editedImage] as? UIImage else {
             KVNProgress.showError(withStatus: R.string.localizable.barcodeNotFound())
             BPLog("Error, image not recognized.")
             return
         }
 
         barcodeDetector
-            .getBarcodeFromImage(originalImage)
+            .getBarcodeFromImage(editedImage)
             .done(on: .main) { [weak self] code in
                 KVNProgress.dismiss()
                 if let code = code {


### PR DESCRIPTION
Zdjęcie teraz można dociąć po wybraniu go z galerii za pomocą wbudowanego edytora. Rozwinięcie https://github.com/KlubJagiellonski/pola-ios/issues/99